### PR TITLE
Time limit can stack when unused!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parental Controls
 
-Adds a server-side per-player time limit.
+Adds a server-side per-player time limit that stacks when unused.
 
 ![Icon featuring a clock and a shield icon](src/main/resources/assets/parentalcontrols/icon.png)
 
@@ -9,7 +9,19 @@ Adds a server-side per-player time limit.
 - Configurable time limit, kick message, etc.
 - Tick-based timer (lag spikes won't count toward elapsed time)
 - Reset at midnight
+- Possibility of stacking unused time (disabled by default)
 
 ## Usage
 
-The default time limit is 8 hours (480 minutes), but this along with some other settings can be changed in the `config/parentalcontrols.json` file. This can be reloaded on the fly with the `/parental reload` command. As a player, you can query your time remaining with the `/parental remaining` command. The time remaining is internally counted per-tick, assuming that the server runs at 20 ticks per second.
+The default time limit is 8 hours (`minutesAllowed: 480`), but this along with some other settings can be changed in the `config/parentalcontrols.json` file. This can be reloaded on the fly with an operator-only command ([see below](#commands)). 
+
+### Time Stacking
+
+Time stacking is disabled by default (`allow_time_stacking: false`). When enabled, any unused time from the daily allowance will be accumulated and carried over to the next day, up to a maximum of `max_stacked_hours` (default: 24 hours).
+The time remaining is internally counted per-tick, but checks are performed every second for better performance (assuming that the server runs at 20 ticks per second).
+
+## Commands
+
+- `/parental remaining`: As a player, query your time remaining
+- `/parental reload`: (Operator-only) Reload the configuration file
+- `/parental status`: (Operator-only) Show time stacking status and each player's accumulated time

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adds a server-side per-player time limit that stacks when unused.
 
-![Icon featuring a clock and a shield icon](src/main/resources/assets/parentalcontrols/icon.png)
+<img src="src/main/resources/assets/parentalcontrols/icon.png" alt="Icon featuring a clock and a shield icon" width="128">
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Adds a server-side per-player time limit that stacks when unused.
 - Tick-based timer (lag spikes won't count toward elapsed time)
 - Reset at midnight
 - Possibility of stacking unused time (disabled by default)
+- Warning system that alerts players when time is running low
 
 ## Usage
 
-The default time limit is 8 hours (`minutesAllowed: 480`), but this along with some other settings can be changed in the `config/parentalcontrols.json` file. This can be reloaded on the fly with an operator-only command ([see below](#commands)). 
+The default time limit is 8 hours (`minutesAllowed: 480`). Players receive a warning message when their remaining time drops to the configured threshold (default: 5 minutes, configurable via `warning_threshold_seconds`). Those, along with some other settings, can be changed in the `config/parentalcontrols.json` file. Settings can be reloaded on the fly with an operator-only command ([see below](#commands)). 
 
 ### Time Stacking
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Parental Controls
 
-Adds a server-side per-player time limit that stacks when unused.
+Adds a server-side per-player time limit.
 
 <img src="src/main/resources/assets/parentalcontrols/icon.png" alt="Icon featuring a clock and a shield icon" width="128">
 
 ## Features
 
-- Configurable time limit, kick message, etc.
+- Configurable time limit, kick message, warning message, etc.
 - Tick-based timer (lag spikes won't count toward elapsed time)
 - Reset at midnight
 - Possibility of stacking unused time (disabled by default)
@@ -19,7 +19,7 @@ The default time limit is 8 hours (`minutesAllowed: 480`). Players receive a war
 ### Time Stacking
 
 Time stacking is disabled by default (`allow_time_stacking: false`). When enabled, any unused time from the daily allowance will be accumulated and carried over to the next day, up to a maximum of `max_stacked_hours` (default: 24 hours).
-The time remaining is internally counted per-tick, but checks are performed every second for better performance (assuming that the server runs at 20 ticks per second).
+The time remaining is internally counted per-tick, but checks are performed every second for better performance (assuming that the server runs at 20 ticks per second). If your server runs at a different tick rate, please update the `check_interval_ticks` config value accordingly.
 
 ## Commands
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ org.gradle.jvmargs=-Xmx1G
 minecraft_version=1.21.6
 yarn_mappings=1.21.6+build.1
 loader_version=0.16.14
-loom_version=1.10.1
+loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0
+mod_version=1.1
 maven_group=lol.sylvie
 archives_base_name=parentalcontrols
 # Dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -25,13 +25,20 @@ public class ParentalControls implements ModInitializer {
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     private static final int TICKS_PER_CHECK = 20; // Check every second (20 ticks)
 
+    private static int dailyAllowance;
+    private static int maxAccumulated;
+
     public static final HashMap<UUID, Integer> ticksUsedToday = new HashMap<>();
     public static final HashMap<UUID, Integer> accumulatedTicks = new HashMap<>();
     private LocalDateTime lastTickTime = LocalDateTime.now();
     private int tickCounter = 0;
 
+    public static void updateTimeConstants() {
+        dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
+        maxAccumulated = (int) (Configuration.INSTANCE.maxStackedHours * 60 * 60 * 20);
+    }
+
     public static int ticksRemaining(UUID player) {
-        int dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
         int usedToday = ticksUsedToday.getOrDefault(player, 0);
         int accumulated = Configuration.INSTANCE.allowTimeStacking ? accumulatedTicks.getOrDefault(player, 0) : 0;
         
@@ -40,7 +47,6 @@ public class ParentalControls implements ModInitializer {
     }
 
     private static void consumeTime(UUID playerId, int ticksToConsume) {
-        int dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
         int usedToday = ticksUsedToday.getOrDefault(playerId, 0);
         int accumulated = accumulatedTicks.getOrDefault(playerId, 0);
         
@@ -117,8 +123,6 @@ public class ParentalControls implements ModInitializer {
 
     private void handleDayTransition() {
         if (Configuration.INSTANCE.allowTimeStacking) {
-            int dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
-            int maxAccumulated = (int) (Configuration.INSTANCE.maxStackedHours * 60 * 60 * 20);
             
             for (UUID playerId : ticksUsedToday.keySet()) {
                 int usedToday = ticksUsedToday.get(playerId);

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -39,6 +39,13 @@ public class ParentalControls implements ModInitializer {
         maxAccumulated = (int) (Configuration.INSTANCE.maxStackedHours * 60 * 60 * 20);
     }
 
+    public static void loadAccumulatedTicksFromConfig() {
+        Configuration.INSTANCE.playerAccumulatedTicks.forEach((playerId, ticks) -> {
+            accumulatedTicks.put(playerId, ticks);
+            LOGGER.info("Loaded {} accumulated ticks for player {} from configuration", ticks, playerId);
+        });
+    }
+
     public static int ticksRemaining(UUID player) {
         int usedToday = ticksUsedToday.getOrDefault(player, 0);
         int accumulated = Configuration.INSTANCE.allowTimeStacking ? accumulatedTicks.getOrDefault(player, 0) : 0;
@@ -151,14 +158,10 @@ public class ParentalControls implements ModInitializer {
                 LOGGER.info("Player {} (offline) received {} leftover ticks, accumulated total: {}", 
                         playerId, leftover, newAccumulated);
             }
-            
-            // Load any accumulated time from configuration
-            Configuration.INSTANCE.playerAccumulatedTicks.forEach((playerId, ticks) -> {
-                if (!accumulatedTicks.containsKey(playerId)) {
-                    int newAccumulated = Math.min(maxAccumulated, ticks + dailyAllowance);
-                    accumulatedTicks.put(playerId, newAccumulated);
-                }
-            });
+
+            Configuration.INSTANCE.playerAccumulatedTicks.clear();
+            Configuration.INSTANCE.playerAccumulatedTicks.putAll(accumulatedTicks);
+            Configuration.save();
         }
         
         ticksUsedToday.clear();

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -136,11 +136,26 @@ public class ParentalControls implements ModInitializer {
                     LOGGER.info("Player {} has {} leftover ticks, accumulated total: {}", playerId, leftover, newAccumulated);
                 }
             }
+
+            for (UUID playerId : new HashSet<>(accumulatedTicks.keySet())) {
+                if (ticksUsedToday.containsKey(playerId)) {
+                    continue;
+                }
+                
+                int leftover = dailyAllowance;
+                int currentAccumulated = accumulatedTicks.get(playerId);
+                int newAccumulated = Math.min(maxAccumulated, currentAccumulated + leftover);
+                accumulatedTicks.put(playerId, newAccumulated);
+                
+                LOGGER.info("Player {} (offline) received {} leftover ticks, accumulated total: {}", 
+                        playerId, leftover, newAccumulated);
+            }
             
             // Load any accumulated time from configuration
             Configuration.INSTANCE.playerAccumulatedTicks.forEach((playerId, ticks) -> {
                 if (!accumulatedTicks.containsKey(playerId)) {
-                    accumulatedTicks.put(playerId, ticks);
+                    int newAccumulated = Math.min(maxAccumulated, ticks + dailyAllowance);
+                    accumulatedTicks.put(playerId, newAccumulated);
                 }
             });
         }

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.UUID;
 
 public class ParentalControls implements ModInitializer {

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -25,10 +25,10 @@ public class ParentalControls implements ModInitializer {
     public static final String MOD_ID = "parentalcontrols";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     private static final int TICKS_PER_CHECK = 20; // Check every second (20 ticks)
-    private static final int WARNING_THRESHOLD_TICKS = 300 * 20; // 5 minutes warning
 
     private static int dailyAllowance;
     private static int maxAccumulated;
+    private static int warningThresholdTicks;
 
     public static final HashMap<UUID, Integer> ticksUsedToday = new HashMap<>();
     public static final HashMap<UUID, Integer> accumulatedTicks = new HashMap<>();
@@ -37,6 +37,7 @@ public class ParentalControls implements ModInitializer {
     private int tickCounter = 0;
 
     public static void updateTimeConstants() {
+        warningThresholdTicks = (int) (Configuration.INSTANCE.warningThresholdSeconds * 20);
         dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
         maxAccumulated = (int) (Configuration.INSTANCE.maxStackedHours * 60 * 60 * 20);
     }
@@ -89,8 +90,8 @@ public class ParentalControls implements ModInitializer {
 
         int remaining = ticksRemaining(playerId);
         
-        if (remaining <= WARNING_THRESHOLD_TICKS && remaining > 0) {
-            int remainingSeconds = WARNING_THRESHOLD_TICKS / 20;
+        if (remaining <= warningThresholdTicks && remaining > 0) {
+            int remainingSeconds = warningThresholdTicks / 20;
             int minutesLeft = remainingSeconds / 60;
             int secondsLeft = remainingSeconds % 60;
             

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -46,7 +46,6 @@ public class ParentalControls implements ModInitializer {
     public static void loadAccumulatedTicksFromConfig() {
         Configuration.INSTANCE.playerAccumulatedTicks.forEach((playerId, ticks) -> {
             accumulatedTicks.put(playerId, ticks);
-            LOGGER.info("Loaded {} accumulated ticks for player {} from configuration", ticks, playerId);
         });
     }
 
@@ -111,8 +110,6 @@ public class ParentalControls implements ModInitializer {
             String warningMessage = Configuration.INSTANCE.warningMessage.replace("%time%", timeMessage);
             player.sendMessage(Text.literal(warningMessage), false);
             playersWarned.add(playerId);
-            
-            LOGGER.info("Warned player {} with {} ticks remaining", playerId, remaining);
         }
     }
 
@@ -182,8 +179,6 @@ public class ParentalControls implements ModInitializer {
                     int currentAccumulated = accumulatedTicks.getOrDefault(playerId, 0);
                     int newAccumulated = Math.min(maxAccumulated, currentAccumulated + leftover);
                     accumulatedTicks.put(playerId, newAccumulated);
-                    
-                    LOGGER.info("Player {} has {} leftover ticks, accumulated total: {}", playerId, leftover, newAccumulated);
                 }
             }
 
@@ -196,9 +191,6 @@ public class ParentalControls implements ModInitializer {
                 int currentAccumulated = accumulatedTicks.get(playerId);
                 int newAccumulated = Math.min(maxAccumulated, currentAccumulated + leftover);
                 accumulatedTicks.put(playerId, newAccumulated);
-                
-                LOGGER.info("Player {} (offline) received {} leftover ticks, accumulated total: {}", 
-                        playerId, leftover, newAccumulated);
             }
 
             Configuration.INSTANCE.playerAccumulatedTicks.clear();

--- a/src/main/java/lol/sylvie/parental/ParentalControls.java
+++ b/src/main/java/lol/sylvie/parental/ParentalControls.java
@@ -34,7 +34,9 @@ public class ParentalControls implements ModInitializer {
         int dailyAllowance = (int) (Configuration.INSTANCE.minutesAllowed * 60 * 20);
         int usedToday = ticksUsedToday.getOrDefault(player, 0);
         int accumulated = Configuration.INSTANCE.allowTimeStacking ? accumulatedTicks.getOrDefault(player, 0) : 0;
-        return dailyAllowance + accumulated - usedToday;
+        
+        int remainingDaily = Math.max(0, dailyAllowance - usedToday);
+        return remainingDaily + accumulated;
     }
 
     public static boolean canPlayerJoin(ServerPlayerEntity player) {

--- a/src/main/java/lol/sylvie/parental/command/ParentalControlsCommand.java
+++ b/src/main/java/lol/sylvie/parental/command/ParentalControlsCommand.java
@@ -60,6 +60,32 @@ public class ParentalControlsCommand {
             return 1;
         }));
 
+        root.then(CommandManager.literal("status").requires(s -> s.hasPermissionLevel(4)).executes(ctx -> {
+            ServerCommandSource source = ctx.getSource();
+            
+            if (!Configuration.INSTANCE.allowTimeStacking) {
+                source.sendMessage(Text.literal("§eTime stacking is disabled."));
+                return 1;
+            }
+            
+            source.sendMessage(Text.literal("§6=== Parental Controls Status ==="));
+            source.sendMessage(Text.literal("§7Time stacking: §aEnabled"));
+            source.sendMessage(Text.literal("§7Max stacked: §f" + Configuration.INSTANCE.maxStackedHours + " hours"));
+            source.sendMessage(Text.literal("§7Daily allowance: §f" + Configuration.INSTANCE.minutesAllowed + " minutes"));
+            
+            if (ParentalControls.accumulatedTicks.isEmpty()) {
+                source.sendMessage(Text.literal("§7No players have accumulated time."));
+            } else {
+                source.sendMessage(Text.literal("§7Players with stacked time:"));
+                ParentalControls.accumulatedTicks.forEach((playerId, ticks) -> {
+                    String formatted = DurationFormatUtils.formatDuration((ticks / 20) * 1000L, "HH:mm:ss");
+                    source.sendMessage(Text.literal("§f" + playerId + "§7: §a" + formatted));
+                });
+            }
+            
+            return 1;
+        }));
+
         dispatcher.register(root);
     }
 }

--- a/src/main/java/lol/sylvie/parental/config/Configuration.java
+++ b/src/main/java/lol/sylvie/parental/config/Configuration.java
@@ -44,11 +44,14 @@ public class Configuration {
             if (INSTANCE.playerAccumulatedTicks == null) {
                 INSTANCE.playerAccumulatedTicks = new HashMap<>();
             }
+
+            ParentalControls.updateTimeConstants();
             
             return true;
         } catch (FileNotFoundException exception) {
             ParentalControls.LOGGER.warn("Configuration file not found.");
             save();
+            ParentalControls.updateTimeConstants();
         } catch (IOException | JsonSyntaxException exception) {
             ParentalControls.LOGGER.error("Couldn't load JSON configuration", exception);
         }

--- a/src/main/java/lol/sylvie/parental/config/Configuration.java
+++ b/src/main/java/lol/sylvie/parental/config/Configuration.java
@@ -74,6 +74,9 @@ public class Configuration {
     
     @SerializedName("max_stacked_hours")
     public float maxStackedHours = 24.0f;
+
+    @SerializedName("warning_threshold_seconds")
+    public int warningThresholdSeconds = 300;
     
     @SerializedName("player_accumulated_ticks")
     public Map<UUID, Integer> playerAccumulatedTicks = new HashMap<>();

--- a/src/main/java/lol/sylvie/parental/config/Configuration.java
+++ b/src/main/java/lol/sylvie/parental/config/Configuration.java
@@ -46,7 +46,8 @@ public class Configuration {
             }
 
             ParentalControls.updateTimeConstants();
-            
+            ParentalControls.loadAccumulatedTicksFromConfig();
+
             return true;
         } catch (FileNotFoundException exception) {
             ParentalControls.LOGGER.warn("Configuration file not found.");

--- a/src/main/java/lol/sylvie/parental/config/Configuration.java
+++ b/src/main/java/lol/sylvie/parental/config/Configuration.java
@@ -4,10 +4,15 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
 import lol.sylvie.parental.ParentalControls;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.*;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class Configuration {
     private static final Gson GSON = new GsonBuilder()
@@ -35,6 +40,11 @@ public class Configuration {
             Configuration parsed = GSON.fromJson(reader, Configuration.class);
             if (parsed == null) return false;
             INSTANCE = parsed;
+
+            if (INSTANCE.playerAccumulatedTicks == null) {
+                INSTANCE.playerAccumulatedTicks = new HashMap<>();
+            }
+            
             return true;
         } catch (FileNotFoundException exception) {
             ParentalControls.LOGGER.warn("Configuration file not found.");
@@ -55,4 +65,12 @@ public class Configuration {
     @SerializedName("exclude_operators")
     public boolean excludeOperators = false;
 
+    @SerializedName("allow_time_stacking")
+    public boolean allowTimeStacking = false;
+    
+    @SerializedName("max_stacked_hours")
+    public float maxStackedHours = 24.0f;
+    
+    @SerializedName("player_accumulated_ticks")
+    public Map<UUID, Integer> playerAccumulatedTicks = new HashMap<>();
 }

--- a/src/main/java/lol/sylvie/parental/config/Configuration.java
+++ b/src/main/java/lol/sylvie/parental/config/Configuration.java
@@ -66,6 +66,9 @@ public class Configuration {
     @SerializedName("disconnect_message")
     public String disconnectMessage = "§cYou have reached your time limit for today.";
 
+    @SerializedName("warning_message")
+    public String warningMessage = "§6⚠ Warning: You have %time% remaining before you're disconnected!";
+
     @SerializedName("exclude_operators")
     public boolean excludeOperators = false;
 
@@ -77,6 +80,9 @@ public class Configuration {
 
     @SerializedName("warning_threshold_seconds")
     public int warningThresholdSeconds = 300;
+
+    @SerializedName("check_interval_ticks")
+    public int checkIntervalTicks = 20;
     
     @SerializedName("player_accumulated_ticks")
     public Map<UUID, Integer> playerAccumulatedTicks = new HashMap<>();


### PR DESCRIPTION
Hi Sylvie!

My friend made a [minecraft modpack](https://www.curseforge.com/minecraft/modpacks/the-wonder-years), so he set up a server for our friend group to have fun with it. Since we don't want to "burn out" the server experience, we imposed a daily time limit, and that's where your mods comes in!
There might be days when people can't play, so i decided to modify the mod to add times which stacks when unused. I modified the code logic to support this feature, using the config file to store the remaining stacked time in case the server gets closed. This setting is disabled by default (as documented in the updated README), but it's easy to enable it and reload the mod on the fly.

I also thought that it might be better to reduce the number of operations performed on each server tick (without compromising the mod funtionality): now the whole body of the function related to `END_SERVER_TICK` is performed once every 20 ticks (1 second), so the mod should be lighter on computational resources. The number of ticks per check costant (`TICKS_PER_CHECK`) can be increased to have less checks, resulting in less accurate kick time, but saving more on computational resources (i like green computing :)

I tested it for the 1.21.5 and it works. Most of the testing was done in 1.21.1 (modpack version), trying all possible scenarios, and eveything works.

If there's anything that could be improved, i'm open to feedbacks! It's the first time i work on a minecraft mod :)

Have a nice day!
-Faxy